### PR TITLE
Adding Filterable Featured Image Size

### DIFF
--- a/framework/highwind-template.php
+++ b/framework/highwind-template.php
@@ -285,7 +285,8 @@ if ( ! function_exists( 'highwind_featured_image' ) ) {
 	function highwind_featured_image() {
 		global $post;
 		if ( ! is_404() ) {
-			$post_image = get_the_post_thumbnail( $post->ID );
+			$post_image_size = apply_filters( 'highwind_featured_image_size', 'large' );
+			$post_image = get_the_post_thumbnail( $post->ID, $post_image_size );
 			echo $post_image;
 		}
 	}


### PR DESCRIPTION
We should add a default image size of `large` instead of `full` for the featured image.

![why_your_company_needs_a_wootrip](https://f.cloud.github.com/assets/1065372/1313891/320ed1cc-3264-11e3-976c-1210e201a681.png)

FYI this is untested since my internet connection is garbage at the moment.
