### PR TITLE
Removing Strange Blockquote Styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -2163,9 +2163,6 @@ blockquote:before {
   font-family: "FontAwesome";
   line-height: 1;
 }
-blockquote + blockquote p:first-child {
-  padding-top: 1.777em;
-}
 code,
 pre {
   background: rgba(0, 0, 0, 0.05);

--- a/style.less
+++ b/style.less
@@ -197,12 +197,6 @@ blockquote {
 	}
 }
 
-blockquote + blockquote {
-	p:first-child {
-		padding-top:1.777em;
-	}
-}
-
 code, pre {
 	background: rgba(0,0,0,0.05);
 	padding:0.1em 0.201em;


### PR DESCRIPTION
There are some strange blockquote styles that don't make any sense to me. They make the content look bizarre. Perhaps they're meant for other areas of the theme (like the footer or something)?

I've removed them since I don't see any reason in them applying to the content area.
## Before

![highwind-blockquote-padding](https://f.cloud.github.com/assets/1065372/1659649/305dabb0-5ba8-11e3-9960-71556d8aadc7.png)

![more-blockquote-madness](https://f.cloud.github.com/assets/1065372/1659651/36a65cf6-5ba8-11e3-8af3-830580925cfc.png)
## After

![after](https://f.cloud.github.com/assets/1065372/1659652/3b2327c8-5ba8-11e3-867f-8bf69faac1de.png)
