### PR TITLE
Fixed duplicated attribute class

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -10,7 +10,7 @@
 
 <?php highwind_comments_before(); ?>
 
-<div id="comments" class="comments" <?php if ( ! comments_open() && post_type_supports( get_post_type(), 'comments' ) && is_page() ) { echo 'class="page-nocomments"'; } ?>>
+<div id="comments" class="comments<?php if ( ! comments_open() && post_type_supports( get_post_type(), 'comments' ) && is_page() ) { echo ' page-nocomments'; } ?>">
 
 	<?php if ( post_password_required() ) : ?>
 


### PR DESCRIPTION
Validating via w3.org it happend to not validate:
snip
"…v id="comments" class="comments" class="page-nocomments"><asid…"
