### PR TITLE
Strip tags from title in data-text attribute

### DIFF
--- a/content-page.php
+++ b/content-page.php
@@ -12,7 +12,7 @@
 
 	<?php highwind_content_header_top(); ?>
 
-	<h1 class="page-title" data-text="<?php the_title(); ?>"><?php the_title(); ?></h1>
+	<h1 class="page-title" data-text="<?php echo wp_strip_all_tags(get_the_title()); ?>"><?php the_title(); ?></h1>
 
 	<?php highwind_content_header_bottom(); ?>
 

--- a/content.php
+++ b/content.php
@@ -13,9 +13,9 @@
 	<?php highwind_content_header_top(); ?>
 
 	<?php if ( is_single() ) : ?>
-		<h1 class="post-title" data-text="<?php the_title(); ?>"><?php the_title(); ?></h1>
+		<h1 class="post-title" data-text="<?php echo wp_strip_all_tags(get_the_title()); ?>"><?php the_title(); ?></h1>
 	<?php else : ?>
-		<h1 class="post-title" data-text="<?php the_title(); ?>"><a href="<?php the_permalink(); ?>" title="<?php printf( esc_attr__( 'Permalink to %s', 'highwind' ), the_title_attribute( 'echo=0' ) ); ?>" rel="bookmark"><?php the_title(); ?></a></h1>
+		<h1 class="post-title" data-text="<?php echo wp_strip_all_tags(get_the_title()); ?>"><a href="<?php the_permalink(); ?>" title="<?php printf( esc_attr__( 'Permalink to %s', 'highwind' ), the_title_attribute( 'echo=0' ) ); ?>" rel="bookmark"><?php the_title(); ?></a></h1>
 	<?php endif; ?>
 
 	<?php highwind_content_header_bottom(); ?>


### PR DESCRIPTION
Strip html tags in data-text attribute on page title. 
Html tags break the title  if there is already a filter which returns title with html tags.
Currently happens if  Easy Digital Downloads is activated.
