### PR TITLE
Search template should use loop.php

### DIFF
--- a/search.php
+++ b/search.php
@@ -27,11 +27,7 @@ get_header();
 
 		<?php /* Start the Loop */ ?>
 
-		<?php while ( have_posts() ) : the_post(); ?>
-
-			<?php get_template_part( 'content', get_post_format() ); ?>
-
-		<?php endwhile; ?>
+		<?php get_template_part( 'loop' ); ?>
 
 	<?php else : ?>
 


### PR DESCRIPTION
In old situation it's a 'custom' loop where it doesn't show things like post meta. By just loading the loop, this is consistent with other pages. It then also shows things like post meta below every post (which isn't included in the current 'custom' search loop).
